### PR TITLE
do not save last_uploaded_plugin_parts in case of error

### DIFF
--- a/encapsia_cli/lib.py
+++ b/encapsia_cli/lib.py
@@ -220,8 +220,10 @@ def run_plugins_task(api, name, params, message, data=None):
     if reply["status"] == "ok":
         log(f"Status: {reply['status']}")
         log_output(reply["output"].strip())
+        return True
     else:
         log_error(str(reply), abort=True)
+        return False
 
 
 def run_job(api, namespace, function, params, data=None):


### PR DESCRIPTION
While developing views for a plugin, you often get the sql wrong. Without this change, `encapsia plugins dev-update` will touch the views timestamp regardless if it failed or not, so you have to manually remove it from .encapsia/last_uploaded_plugin_parts.toml.