### PR TITLE
#79: replace request to deprecated pluginsmanager API

### DIFF
--- a/encapsia_cli/plugininfo.py
+++ b/encapsia_cli/plugininfo.py
@@ -229,11 +229,10 @@ class PluginInfos:
 
     @staticmethod
     def make_from_encapsia(host: str) -> PluginInfos:
-        # TODO: use pluginsmanager.plugins() if it exists
         api = lib.get_api(host=host)
         raw_info = api.run_view(
             "pluginsmanager",
-            "installed_plugins_with_tags",
+            "plugins",
         )
         pis = []
         for i in raw_info:

--- a/encapsia_cli/plugininfo.py
+++ b/encapsia_cli/plugininfo.py
@@ -236,7 +236,7 @@ class PluginInfos:
         )
         pis = []
         for i in raw_info:
-            tags = i.get("plugin_tags")
+            tags = i.get("manifest").get("tags")
             if not isinstance(tags, list):
                 tags = []
             try:


### PR DESCRIPTION
This improves issue #79 where installed_plugins_with_tags() is deprecated in favor of plugins() function.