### PR TITLE
#62: Display a nice message when a config get key is missing, instead of a traceback

### DIFF
--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -42,9 +42,12 @@ def load(obj, input):
 @click.pass_obj
 def get(obj, key):
     """Retrieve value against given key."""
-    api = lib.get_api(**obj)
-    value = api.get_config(key)
-    lib.pretty_print(value, "json")
+    try:
+        api = lib.get_api(**obj)
+        value = api.get_config(key)
+        lib.pretty_print(value, "json")
+    except KeyError as e:
+        lib.log_error(f"error: could not get key {e}: No configuration with this key!")
 
 
 @main.command()

--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -46,8 +46,11 @@ def get(obj, key):
     try:
         value = api.get_config(key)
     except KeyError as e:
-        lib.log_error(f"error: could not get key {e}: No configuration with this key!", abort=True)
+        lib.log_error(
+            f"error: could not get key {e}: No configuration with this key!", abort=True
+        )
     lib.pretty_print(value, "json")
+
 
 @main.command()
 @click.argument("key")

--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -42,8 +42,8 @@ def load(obj, input):
 @click.pass_obj
 def get(obj, key):
     """Retrieve value against given key."""
+    api = lib.get_api(**obj)
     try:
-        api = lib.get_api(**obj)
         value = api.get_config(key)
         lib.pretty_print(value, "json")
     except KeyError as e:

--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -1,4 +1,3 @@
-from ast import Break
 import click
 
 from encapsia_cli import lib

--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -1,3 +1,4 @@
+from ast import Break
 import click
 
 from encapsia_cli import lib
@@ -45,10 +46,10 @@ def get(obj, key):
     api = lib.get_api(**obj)
     try:
         value = api.get_config(key)
-        lib.pretty_print(value, "json")
     except KeyError as e:
         lib.log_error(f"error: could not get key {e}: No configuration with this key!")
-
+        return
+    lib.pretty_print(value, "json")
 
 @main.command()
 @click.argument("key")

--- a/encapsia_cli/config.py
+++ b/encapsia_cli/config.py
@@ -46,8 +46,7 @@ def get(obj, key):
     try:
         value = api.get_config(key)
     except KeyError as e:
-        lib.log_error(f"error: could not get key {e}: No configuration with this key!")
-        return
+        lib.log_error(f"error: could not get key {e}: No configuration with this key!", abort=True)
     lib.pretty_print(value, "json")
 
 @main.command()


### PR DESCRIPTION
In #62 'config get' command was showing a complex traceback that was not so intuitive of it's nature.