### PR TITLE
Installing and adding to local_store groups of plugins with one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed installing plugin using file path. #76.
 - `plugins add` will now abort if it cannot find some of the requested specs in S3
 - Clocked httpie to 3.1.0 to fix security vulnerabilities.
 
 ### Added
 
+- Support for adding to local_store groups of plugins with one command. #87.
+- Support for installing groups of plugins with one command. #87.
 - A new `token transfer` subcommand, allowing to obtain a token for a different user (current user's credentials permitting) and printing it out as plain text or shell command setting encapsia environment variables.
 - A new `token env` subcommand that just prints out shell commands to set environment variables `ENCAPSIA_URL` and `ENCAPSIA_TOKEN`.
 
 ### Changed
 
+- Display a message when a config get key is missing, instead of a traceback. #62.
+- Replaced request to deprecated pluginsmanager API. #79.
 - The `token extend` subcommand gained ability to display extended token (both as plain text or as shell commands setting environment), instead of storing in credentials file.
 - The `token extend` now allows you to set capabilities (as a subset of existing capabilities).
 

--- a/encapsia_cli/plugininfo.py
+++ b/encapsia_cli/plugininfo.py
@@ -284,7 +284,6 @@ class PluginSpec:
     variant: T_Variant
     version_prefix: str = ""
     exact_match: bool = False
-    from_s3: bool = False
 
     PLUGIN_SPEC_NVV_REGEX: T.ClassVar[re.Pattern] = re.compile(
         rf"^({ALLOWED_PLUGIN_NAME})(?:-variant-({ALLOWED_VARIANT}))?(?:-({ALLOWED_VERSION}))?$"
@@ -361,14 +360,15 @@ class PluginSpec:
 
     @classmethod
     def make_from_plugininfo(
-        cls, plugininfo: PluginInfo, exact_match: bool = True, from_s3: bool = False
+        cls,
+        plugininfo: PluginInfo,
+        exact_match: bool = True,
     ) -> PluginSpec:
         return cls(
             plugininfo.name,
             plugininfo.variant,
             plugininfo.version,
             exact_match=exact_match,
-            from_s3=from_s3
         )
 
     def _variant_match(self, pi: PluginInfo) -> bool:

--- a/encapsia_cli/plugininfo.py
+++ b/encapsia_cli/plugininfo.py
@@ -284,6 +284,7 @@ class PluginSpec:
     variant: T_Variant
     version_prefix: str = ""
     exact_match: bool = False
+    from_s3: bool = False
 
     PLUGIN_SPEC_NVV_REGEX: T.ClassVar[re.Pattern] = re.compile(
         rf"^({ALLOWED_PLUGIN_NAME})(?:-variant-({ALLOWED_VARIANT}))?(?:-({ALLOWED_VERSION}))?$"
@@ -360,13 +361,14 @@ class PluginSpec:
 
     @classmethod
     def make_from_plugininfo(
-        cls, plugininfo: PluginInfo, exact_match: bool = True
+        cls, plugininfo: PluginInfo, exact_match: bool = True, from_s3: bool = False
     ) -> PluginSpec:
         return cls(
             plugininfo.name,
             plugininfo.variant,
             plugininfo.version,
             exact_match=exact_match,
+            from_s3=from_s3
         )
 
     def _variant_match(self, pi: PluginInfo) -> bool:

--- a/encapsia_cli/plugins.py
+++ b/encapsia_cli/plugins.py
@@ -158,12 +158,7 @@ def _install_plugin(api, filename: Path, print_output: bool = False):
     "s3_buckets",
     type=str,
     multiple=True,
-    default=[
-        "encapsia-plugins/cmedtech/pd/staging/apps",
-        "encapsia-plugins/cmedtech/pd/staging/middleware",
-        "encapsia-plugins/cmedtech/pd/staging/insights",
-        "ice-plugins",
-    ],
+    default="ice-plugins",
     help="Name of AWS S3 bucket (or path) containing plugins (may be provided multiple times).",
 )
 @click.option(

--- a/encapsia_cli/plugins.py
+++ b/encapsia_cli/plugins.py
@@ -647,7 +647,7 @@ def add(obj, versions, latest_existing, all_available, plugins):
                     plugin, plugins_local_dir, force=plugins_force
                 )
         else:
-            lib.log("No plugins found in: {plugins_s3_buckets}.")
+            lib.log(f"No plugins found in: {plugins_s3_buckets}.")
         return
 
     for plugin in plugins:

--- a/encapsia_cli/plugins.py
+++ b/encapsia_cli/plugins.py
@@ -94,6 +94,7 @@ def _add_to_local_store_from_s3(
                 f"Downloaded {pi.get_s3_bucket()}/{pi.get_s3_name()} and saved to {target}"
             )
 
+
 def _add_to_temp_store_from_s3(
     pi: PluginInfo, plugins_local_dir: Path, force: bool = False
 ):
@@ -103,7 +104,7 @@ def _add_to_temp_store_from_s3(
     if not os.path.exists(temp_os_path):
         os.mkdir(temp_os_path)
 
-    temp_directory = plugins_local_dir/temp_directory_string
+    temp_directory = plugins_local_dir / temp_directory_string
     _add_to_local_store_from_s3(pi, temp_directory, force)
 
 
@@ -162,9 +163,9 @@ def _install_plugin(api, filename: Path, print_output: bool = False):
         is_idempotent=True,  # re-installing a plugin should be safe
     )
 
+
 def _cleanup(temp_path):
     shutil.rmtree(temp_path)
-    print("Removed temp file")
 
 
 @click.group("plugins")
@@ -345,9 +346,6 @@ def install(obj, versions, show_logs, latest_existing, plugins):
 
     # Temporarily get the plugins from S3
     for s3_plugin in s3_plugins:
-        print("s3 bucket ->" + s3_plugin.get_s3_bucket())
-        print("s3 name ->" + s3_plugin.get_s3_name())
-
         _add_to_temp_store_from_s3(s3_plugin, plugins_local_dir, force=plugins_force)
         plugin_info = PluginSpec.make_from_plugininfo(s3_plugin, from_s3=True)
         to_install_candidates.append(plugin_info)

--- a/encapsia_cli/plugins.py
+++ b/encapsia_cli/plugins.py
@@ -153,7 +153,6 @@ def _download_plugins_from_s3(
         for plugin in plugins_to_download:
             _add_to_local_store_from_s3(plugin, plugins_local_dir, force=plugins_force)
     else:
-        print("HERE")
         if not added_from_file_or_uri:
             lib.log("Nothing to do!")
 


### PR DESCRIPTION
Fixes #87

Tested using:

`encapsia plugins --s3-bucket=encapsia-plugins/cmedtech/pd/production/insights/ --s3-bucket encapsia-plugins/cmedcro/standards/production/insights install`

`encapsia plugins --s3-bucket=encapsia-plugins/cmedtech/pd/production/insights/ --s3-bucket encapsia-plugins/cmedcro/standards/production/insights add`