### PR TITLE
address path traversal in tarfile.extractall by not using it

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg,
+extend-exclude = .venv,.coverage,.mypy_cache,.pytest_cache,dist,htmlcov,build,tmp
 max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501,W503,E203

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed installing plugin using file path. #76.
 - `plugins add` will now abort if it cannot find some of the requested specs in S3
 - Clocked httpie to 3.1.0 to fix security vulnerabilities.
+- Replaced implementation using `tarfile.extractall` of `encapsia plugins ls`, that is
+  vulnerable to a path traversal attack. See
+  https://github.com/python/cpython/issues/73974 and
+  https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html
 
 ### Added
 

--- a/encapsia_cli/plugins.py
+++ b/encapsia_cli/plugins.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import urllib.request
 from contextlib import contextmanager
+from io import TextIOWrapper
 from pathlib import Path
 
 import click
@@ -762,11 +763,9 @@ def ls(obj, all_versions, long_format, plugins):
     def _read_description(pi):
         filename = plugins_local_dir / pi.get_filename()
         try:
-            with lib.temp_directory() as tmp_dir:
-                lib.extract_targz(filename, tmp_dir)
-                manifests = list(tmp_dir.glob("**/plugin.toml"))
-                return lib.read_toml(manifests[0])["description"]
-        except Exception:
+            with lib.open_targz_member(filename, "plugin.toml") as f:
+                return lib.read_toml(TextIOWrapper(f))["description"]
+        except SyntaxError:
             lib.log_error(f"Malformed? Unable to read: {filename}")
             return "N/A"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,14 @@ shellingham = "^1.4.0"
 httpie-shell = ["http-prompt"]
 
 [tool.poetry.dev-dependencies]
-black = {version = "^20.8b1",allow-prereleases = true}
 isort = "^5.5"
 flake8 = "^3.7"
 ansi2html = "^1.5"
 mypy = "^0.782"
 pytest = "^6.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^21.12b0"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -45,6 +47,10 @@ addopts = "-ra"
 testpaths = [
     "tests",
 ]
+
+[tool.black]
+line-length = 88
+target_version = ['py38']
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
This is in response to #97 but instead of re-implementing `tarfile.extractall`, since we don't need all the files, just look for the plugin.toml file in the archives. A small benefit is that it doesn't hit the disk with a temp file.